### PR TITLE
Remove navigation from checklist item and summary edit pages

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,13 +1,8 @@
-import React, { FunctionComponent } from 'react';
+import React, { CSSProperties, FunctionComponent } from 'react';
 import styled, { css } from 'styled-components';
 import { FluidObject } from 'gatsby-image';
 
-import {
-  baseSpacer,
-  breakpoints,
-  doubleSpacer,
-  quadrupleSpacer,
-} from '@styles/size';
+import { baseSpacer, breakpoints, doubleSpacer, quadrupleSpacer } from '@styles/size';
 import { white } from '@styles/color';
 import { baseBorderStyle, z1Shadow, z2Shadow, z3Shadow, z4Shadow } from '@styles/mixins';
 
@@ -24,6 +19,7 @@ type BoxProps = {
     };
   };
   onClick?: () => void;
+  style?: CSSProperties;
 };
 
 const renderShadow = (zindex: number) => {

--- a/src/components/PackingListNavigation.tsx
+++ b/src/components/PackingListNavigation.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+import { useLocation } from '@reach/router';
+
+import { brandPrimary, white, textColor } from '@styles/color';
+import { baseSpacer } from '@styles/size';
+import { baseBorderStyle } from '@styles/mixins';
+
+const Tabs = styled.div`
+  margin-top: calc(-${baseSpacer} - 1px);
+  background-color: ${white};
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+  border-bottom: ${baseBorderStyle};
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  right: 0;
+`;
+
+const Tab = styled.div`
+  transition: all 0.2s ease-in-out;
+  flex: 1;
+  text-align: center;
+  border-bottom: 2px solid;
+  border-bottom-color: ${(props: { active: boolean }) =>
+    props.active ? brandPrimary : 'transparent'};
+  color: ${(props) => (props.active ? brandPrimary : textColor)};
+
+  & a {
+    display: block;
+    padding: ${baseSpacer};
+  }
+`;
+
+type PackingListNavigationProps = { tripId: string };
+
+const PackingListNavigation = ({ tripId }: PackingListNavigationProps) => {
+  const { pathname } = useLocation();
+  const summaryActive = pathname.includes('summary') || pathname.includes('edit');
+  const checklistActive = !summaryActive || pathname.includes('checklist');
+
+  return (
+    <Tabs>
+      <Tab active={checklistActive}>
+        <Link to={`/app/trips/${tripId}`}>Checklist</Link>
+      </Tab>
+      <Tab active={summaryActive}>
+        <Link to={`/app/trips/${tripId}/summary`}>Summary</Link>
+      </Tab>
+    </Tabs>
+  );
+};
+
+export const packingListNavigationHeight = 54;
+export default PackingListNavigation;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -30,6 +30,7 @@ import NegativeMarginContainer from './NegativeMarginContainer';
 import PackingListAddItem from './PackingListAddItem';
 import PackingListCategory from './PackingListCategory';
 import PackingListItem from './PackingListItem';
+import PackingListNavigation, { packingListNavigationHeight } from './PackingListNavigation';
 import PageContainer from './PageContainer';
 import Pill from './Pill';
 import PreviewCompatibleImage from './PreviewCompatibleImage';
@@ -81,6 +82,8 @@ export {
   PackingListAddItem,
   PackingListCategory,
   PackingListItem,
+  PackingListNavigation,
+  packingListNavigationHeight,
   PageContainer,
   Pill,
   PreviewCompatibleImage,

--- a/src/views/PackingList.tsx
+++ b/src/views/PackingList.tsx
@@ -2,7 +2,11 @@ import React, { FunctionComponent } from 'react';
 import lodash from 'lodash';
 import { RouteComponentProps } from '@reach/router';
 
-import { PackingListCategory } from '@components';
+import {
+  PackingListCategory,
+  PackingListNavigation,
+  packingListNavigationHeight,
+} from '@components';
 import { PackingListItemType } from '@common/packingListItem';
 
 type PackingListProps = {
@@ -24,29 +28,32 @@ const PackingList: FunctionComponent<PackingListProps> = ({ packingList, tripId 
 
   return (
     <>
-      {groupedCategories.map(
-        ([categoryName, packingListItems]: [string, PackingListItemType[]]) => {
-          const sortedItems = packingListItems.sort((a, b) => {
-            // put essentials at the top, and sort by created timestamp (newest goes last)
-            if (!a.isEssential && !b.isEssential) {
-              if (a.created.seconds === b.created.seconds) {
-                return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+      <PackingListNavigation tripId={tripId} />
+      <div style={{ paddingTop: packingListNavigationHeight }}>
+        {groupedCategories.map(
+          ([categoryName, packingListItems]: [string, PackingListItemType[]]) => {
+            const sortedItems = packingListItems.sort((a, b) => {
+              // put essentials at the top, and sort by created timestamp (newest goes last)
+              if (!a.isEssential && !b.isEssential) {
+                if (a.created.seconds === b.created.seconds) {
+                  return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+                }
+                return b.created.toDate() > a.created.toDate() ? -1 : 1;
               }
-              return b.created.toDate() > a.created.toDate() ? -1 : 1;
-            }
-            return a.isEssential > b.isEssential ? -1 : 1;
-          });
+              return a.isEssential > b.isEssential ? -1 : 1;
+            });
 
-          return (
-            <PackingListCategory
-              key={categoryName}
-              categoryName={categoryName}
-              sortedItems={sortedItems}
-              tripId={tripId}
-            />
-          );
-        }
-      )}
+            return (
+              <PackingListCategory
+                key={categoryName}
+                categoryName={categoryName}
+                sortedItems={sortedItems}
+                tripId={tripId}
+              />
+            );
+          }
+        )}
+      </div>
     </>
   );
 };

--- a/src/views/TripById.tsx
+++ b/src/views/TripById.tsx
@@ -1,17 +1,12 @@
 import React, { FunctionComponent, useEffect } from 'react';
-import { RouteComponentProps, Router, useLocation } from '@reach/router';
+import { RouteComponentProps, Router } from '@reach/router';
 import { useFirestoreConnect, isLoaded, isEmpty } from 'react-redux-firebase';
 import { useSelector, useDispatch } from 'react-redux';
 import { actionTypes } from 'redux-firestore';
-import styled from 'styled-components';
-import { Link } from 'gatsby';
 
 import { Seo, PageContainer } from '@components';
 import { RootState } from '@redux/ducks';
 import { TripType } from '@common/trip';
-import { brandPrimary, white, textColor } from '@styles/color';
-import { baseSpacer } from '@styles/size';
-import { baseBorderStyle } from '@styles/mixins';
 import PackingList from '@views/PackingList';
 import TripSummary from '@views/TripSummary';
 import EditPackingListItem from '@views/EditPackingListItem';
@@ -21,38 +16,8 @@ type TripByIdProps = {
   id?: string;
 } & RouteComponentProps;
 
-const Tabs = styled.div`
-  margin-top: calc(-${baseSpacer} - 1px);
-  background-color: ${white};
-  display: flex;
-  justify-content: space-between;
-  cursor: pointer;
-  border-bottom: ${baseBorderStyle};
-  position: fixed;
-  z-index: 1;
-  left: 0;
-  right: 0;
-`;
-
-const Tab = styled.div`
-  transition: all 0.2s ease-in-out;
-  flex: 1;
-  text-align: center;
-  border-bottom: 2px solid;
-  border-bottom-color: ${(props: { active: boolean }) =>
-    props.active ? brandPrimary : 'transparent'};
-  color: ${(props) => (props.active ? brandPrimary : textColor)};
-
-  & a {
-    display: block;
-    padding: ${baseSpacer};
-  }
-`;
-
 const TripById: FunctionComponent<TripByIdProps> = (props) => {
   const dispatch = useDispatch();
-
-  const { pathname } = useLocation();
 
   const activeTripById: Array<TripType> = useSelector(
     (state: RootState) => state.firestore.ordered.activeTripById
@@ -93,30 +58,19 @@ const TripById: FunctionComponent<TripByIdProps> = (props) => {
     };
   }, []);
 
-  if (!props.id) {
+  if (!activeTrip || !props.id) {
     return null;
   }
-
-  const summaryActive = pathname.includes('summary') || pathname.includes('edit');
-  const checklistActive = !summaryActive || pathname.includes('checklist');
 
   return (
     <>
       <Seo title={activeTrip?.name || 'Trip Summary'} />
 
-      <Tabs>
-        <Tab active={checklistActive}>
-          <Link to={`/app/trips/${props.id}`}>Checklist</Link>
-        </Tab>
-        <Tab active={summaryActive}>
-          <Link to={`/app/trips/${props.id}/summary`}>Summary</Link>
-        </Tab>
-      </Tabs>
       <PageContainer>
-        <Router basepath={`/app/trips/${props.id}`} style={{ paddingTop: 54 }} primary={false}>
+        <Router basepath={`/app/trips/${props.id}`} primary={false} style={{ overflow: 'hidden' }}>
           <PackingList path="/" packingList={packingList} tripId={props.id} />
           <TripSummary path="/summary" activeTrip={activeTrip} />
-          <EditTripSummary path="/edit" activeTrip={activeTrip} />
+          <EditTripSummary path="/summary/edit" activeTrip={activeTrip} />
           <EditPackingListItem path="/checklist/:id" tripId={props.id} />
         </Router>
       </PageContainer>

--- a/src/views/TripSummary.tsx
+++ b/src/views/TripSummary.tsx
@@ -19,6 +19,8 @@ import {
   Modal,
   Row,
   Column,
+  PackingListNavigation,
+  packingListNavigationHeight,
 } from '@components';
 import { halfSpacer } from '@styles/size';
 import { TripType } from '@common/trip';
@@ -27,7 +29,7 @@ import { UserType } from '@common/user';
 import { addAlert } from '@redux/ducks/globalAlerts';
 
 type TripSummaryProps = {
-  activeTrip?: TripType;
+  activeTrip: TripType;
 } & RouteComponentProps;
 
 const TripSummary: FunctionComponent<TripSummaryProps> = ({ activeTrip }) => {
@@ -67,7 +69,8 @@ const TripSummary: FunctionComponent<TripSummaryProps> = ({ activeTrip }) => {
 
   return (
     <>
-      <Box>
+      <PackingListNavigation tripId={activeTrip.tripId} />
+      <Box style={{ marginTop: packingListNavigationHeight }}>
         <FlexContainer justifyContent="space-between" alignItems="flex-start" flexWrap="nowrap">
           {activeTrip ? (
             <Heading as="h3" altStyle noMargin>
@@ -81,7 +84,7 @@ const TripSummary: FunctionComponent<TripSummaryProps> = ({ activeTrip }) => {
               <Button
                 type="link"
                 color="text"
-                to={`/app/trips/${activeTrip.tripId}/edit`}
+                to={`/app/trips/${activeTrip.tripId}/summary/edit`}
                 iconLeft={<FaPencilAlt />}
                 block
               >


### PR DESCRIPTION
I removed the navigation from both the "checklist item" and "summary edit" pages. Not sure if that was your intention with the task, but the patterns seemed to align.

If you want me to undo it on the summary edit page, that's easy enough to revert.