### PR TITLE
Gear closet in generator

### DIFF
--- a/src/views/TripGenerator.tsx
+++ b/src/views/TripGenerator.tsx
@@ -57,6 +57,7 @@ const usePersonalGear = () => {
   const gearClosetRemovals = fetchedGearCloset?.[0]?.removals ?? [];
   const gearClosetAdditions = fetchedGearClosetAdditions ?? [];
 
+  // Only regenerate this data if the master gear, gear closet removals, or gear closet additions change
   const personalGear = useMemo(() => {
     // Shallow clone the gear list, so we don't modify the master gear list
     let customizedGear = [...masterGear];


### PR DESCRIPTION
**Overview**
This PR introduce the functionality allowing for custom gear closets to integrate with the trip generation, based on two lists of "additions" and "removals" from the master gear list.

**Schema**
I created a new collection in Firestore: https://console.firebase.google.com/project/getpackup/firestore/data~2Fgear-closet~2FNLDQDSt5TISqK96HVffGhsQlboU2

- The document ID for each item in the gear closet should match the user ID, allowing for easy lookups.
- Each document includes both "additions" (a sub-collection) and "removals" (an array of IDs to remove). As someone updates their gear closet, this database will be documented with the changes the user makes. (to be developed in a separate PR)
- Additions should match the schema of items in the "gear" collection, with a couple of small exceptions in metadata.
- "activities" is the selection of activities that the user participates in, that way we don't show absolutely everything in our master list, in the user's personal closet. (functionality not included in this PR)

**Testing**
- Login with a user account that has gear-closet populated in the database (DM me if you want my login credentials, so you don't have to clone my document).
- Generate a new trip, for the data already populated in the database, select "snowshoeing" and "car camping". 
- Based on the existing data in the database, "snowshoes" should not appear in the gear list, and "Coffee setup - Aeropress" should appear in the gear list.